### PR TITLE
fix slider width when items have some padding

### DIFF
--- a/jquery.bxslider-rahisified.js
+++ b/jquery.bxslider-rahisified.js
@@ -1445,7 +1445,7 @@
 		 */
 		el.redrawSlider = function(){
 			// resize all children in ratio to new screen size
-			slider.children.add(el.find('.bx-clone')).width(calcSlideWidthidth());
+			slider.children.add(el.find('.bx-clone')).outerWidth(calcSlideWidthidth());
 			// adjust the height
 			slider.viewport.css('height', getViewportHeight());
 			// update the slide position


### PR DESCRIPTION
When sliders items have some padding, the item's width is not correctly set.
Using `.outerWidth()` method instead of `.width()` in the `.redrawSlider()` function seems to fix the problem.
